### PR TITLE
#10 |  UX show regenerate only when input or settings changed

### DIFF
--- a/front-end/src/components/CardBlock/CardRight.tsx
+++ b/front-end/src/components/CardBlock/CardRight.tsx
@@ -27,6 +27,7 @@ interface CardRightProps {
   loading: boolean;
   includeTime: boolean;
   clearAll: () => void;
+  changeInput: boolean;
   input: string;
 }
 
@@ -36,6 +37,7 @@ const CardRight = ({
   loading,
   includeTime,
   clearAll,
+  changeInput,
   input,
 }: CardRightProps) => {
   const FOCUS_SECONDS = 10 * 60;
@@ -47,7 +49,6 @@ const CardRight = ({
   const [timerOpen, setTimerOpen] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [secondsLeft, setSecondsLeft] = useState(FOCUS_SECONDS);
-  const [changeInput, setChangeInput] = useState("");
 
   const onCopy = async () => {
     if (!plan) return;
@@ -144,12 +145,6 @@ const CardRight = ({
     setSecondsLeft(FOCUS_SECONDS);
   }, [plan?.firstAction]);
 
-  console.info(changeInput === input, "changeInput === input");
-
-  useEffect(() => {
-    setChangeInput(input);
-  }, []);
-
   return (
     <Card
       className={cn(
@@ -210,7 +205,7 @@ const CardRight = ({
                   variant="outline"
                   className="rounded-full cursor-pointer"
                   onClick={onGenerate}
-                  disabled={loading || changeInput === input}
+                  disabled={loading || changeInput || !input}
                 >
                   Regenerate
                 </Button>

--- a/front-end/src/components/CardBlock/CardRight.tsx
+++ b/front-end/src/components/CardBlock/CardRight.tsx
@@ -27,6 +27,7 @@ interface CardRightProps {
   loading: boolean;
   includeTime: boolean;
   clearAll: () => void;
+  input: string;
 }
 
 const CardRight = ({
@@ -35,6 +36,7 @@ const CardRight = ({
   loading,
   includeTime,
   clearAll,
+  input,
 }: CardRightProps) => {
   const FOCUS_SECONDS = 10 * 60;
 
@@ -45,6 +47,7 @@ const CardRight = ({
   const [timerOpen, setTimerOpen] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [secondsLeft, setSecondsLeft] = useState(FOCUS_SECONDS);
+  const [changeInput, setChangeInput] = useState("");
 
   const onCopy = async () => {
     if (!plan) return;
@@ -141,6 +144,12 @@ const CardRight = ({
     setSecondsLeft(FOCUS_SECONDS);
   }, [plan?.firstAction]);
 
+  console.info(changeInput === input, "changeInput === input");
+
+  useEffect(() => {
+    setChangeInput(input);
+  }, []);
+
   return (
     <Card
       className={cn(
@@ -201,7 +210,7 @@ const CardRight = ({
                   variant="outline"
                   className="rounded-full cursor-pointer"
                   onClick={onGenerate}
-                  disabled={loading}
+                  disabled={loading || changeInput === input}
                 >
                   Regenerate
                 </Button>

--- a/front-end/src/components/PageContainer/PageContainer.tsx
+++ b/front-end/src/components/PageContainer/PageContainer.tsx
@@ -94,6 +94,7 @@ const PageContainer = () => {
         />
 
         <CardRight
+        input={input}
           plan={plan}
           onGenerate={onGenerate}
           loading={loading}

--- a/front-end/src/components/PageContainer/PageContainer.tsx
+++ b/front-end/src/components/PageContainer/PageContainer.tsx
@@ -21,6 +21,7 @@ const PageContainer = () => {
   const [mode, setMode] = useState<"fast" | "deep">("fast");
   const [tone, setTone] = useState<"strict" | "soft">("strict");
   const [includeTime, setIncludeTime] = useState(true);
+  const [messageChanged, setMessageChanged] = useState<string>("");
 
   const remaining = 3;
 
@@ -31,6 +32,7 @@ const PageContainer = () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ input, mode, tone, includeTime }),
     });
+    setMessageChanged(input);
 
     if (!planRes.ok) {
       const errText = await planRes.text();
@@ -48,11 +50,16 @@ const PageContainer = () => {
     return { plan };
   };
 
+  const normalize = (v: string) => v.trim();
+
+  const hasInputChanged =
+    !!messageChanged && normalize(input) === normalize(messageChanged);
+
   const clearAll = () => {
-    setInput('');
+    setInput("");
     setPlan(null);
     setLoading(false);
-  }
+  };
 
   return (
     <div className="min-h-screen bg-background">
@@ -94,7 +101,8 @@ const PageContainer = () => {
         />
 
         <CardRight
-        input={input}
+          input={input}
+          changeInput={hasInputChanged}
           plan={plan}
           onGenerate={onGenerate}
           loading={loading}


### PR DESCRIPTION
Regenerate button disabled when `input` is empty or message changed 